### PR TITLE
Highlight Script fix

### DIFF
--- a/src/Highlight/contentScript.ts
+++ b/src/Highlight/contentScript.ts
@@ -57,6 +57,7 @@ function getSelectedText(): string {
 	) {
 		text = (document as any).selection.createRange().text;
 	}
+	console.log("Selected text: ", text);
 	return text;
 }
 
@@ -68,20 +69,7 @@ function highlightText(): ActionResponse {
 		let selectedText: string = getSelectedText();
 
 		if (selectedText) {
-			let mark: HTMLElement = document.createElement("mark");
-			mark.setAttribute("style", `background-color: #${color}`);
-			mark.className = HIGHLIGHT_KEY;
-			let sel: Selection | null = window.getSelection();
-
-			if (sel?.rangeCount) {
-				let range: Range = sel.getRangeAt(0).cloneRange();
-				range.surroundContents(mark);
-				sel.removeAllRanges();
-				sel.addRange(range);
-
-				// TODO: return highlight for persistence in collab
-				return { success: true };
-			}
+			highlight();
 
 			return { error: "Failed to create highlight" };
 		}
@@ -90,6 +78,22 @@ function highlightText(): ActionResponse {
 	}
 
 	return { error: "Already highlighted" };
+}
+
+/* Insert mark around selected text */
+function highlight() {
+	let mark: HTMLElement = document.createElement("mark");
+	mark.setAttribute("style", `background-color: #${color}`);
+	mark.className = HIGHLIGHT_KEY;
+	let sel: Selection | null = window.getSelection();
+
+	if (sel?.rangeCount) {
+		let range: Range = sel.getRangeAt(0).cloneRange();
+		range.surroundContents(mark);
+		sel.removeAllRanges();
+		sel.addRange(range);
+		return { success: true };
+	}
 }
 
 /* Remove highlight for given selected text */

--- a/src/Nostr/utils.ts
+++ b/src/Nostr/utils.ts
@@ -9,3 +9,8 @@ export const getNostrUser = async (): Promise<NostrUser> => {
 
 	return mockNostrUser;
 };
+
+
+// const pubKey = (): string => {
+// 	return window.nostr.getPublicKey().toString();
+// }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ module.exports = (env) => {
 				// https://github.com/webpack/webpack/issues/7939
 				devtoolNamespace: "colighter",
 				libraryTarget: "umd",
+				publicPath: "",
 			},
 			plugins: [
 				new webpack.ProvidePlugin({


### PR DESCRIPTION
This PR is a little fix to 

- ContentScript not returning highlighted text(currently console logged) 
- webpack not providing a public path for module access. added a public path key to the outputs