### PR TITLE
fix: make background script synchronous after installation

### DIFF
--- a/apps/extension/src/ext_background.ts
+++ b/apps/extension/src/ext_background.ts
@@ -12,53 +12,53 @@ chrome.runtime.onInstalled.addListener(() => {
     title: 'Remove Highlight',
     contexts: ['selection'],
   });
+});
 
-  chrome.contextMenus.onClicked.addListener((info, tab) => {
-    let tabId = tab?.id;
-    if (tabId === undefined) return;
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  let tabId = tab?.id;
+  if (tabId === undefined) return;
 
-    if (info.menuItemId === 'create-highlight') {
+  if (info.menuItemId === 'create-highlight') {
+    chrome.tabs
+      .sendMessage(tabId, { action: MessageAction.RENDER_HIGHLIGHTS })
+      .catch((err) => {
+        console.log(err);
+      });
+
+    return;
+  }
+
+  if (info.menuItemId === 'remove-highlight') {
+    chrome.tabs
+      .sendMessage(tabId, { action: MessageAction.REMOVE_HIGHLIGHTS })
+      .catch((err) => {
+        console.log(err);
+      });
+    return;
+  }
+});
+
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command === 'create-highlight') {
+    tab.id !== undefined &&
       chrome.tabs
-        .sendMessage(tabId, { action: MessageAction.RENDER_HIGHLIGHTS })
+        .sendMessage(tab.id, { action: MessageAction.RENDER_HIGHLIGHTS })
         .catch((err) => {
           console.log(err);
         });
+  }
+});
 
-      return;
-    }
-
-    if (info.menuItemId === 'remove-highlight') {
-      chrome.tabs
-        .sendMessage(tabId, { action: MessageAction.REMOVE_HIGHLIGHTS })
-        .catch((err) => {
-          console.log(err);
-        });
-      return;
-    }
-  });
-
-  chrome.commands.onCommand.addListener((command, tab) => {
-    if (command === 'create-highlight') {
-      tab.id !== undefined &&
-        chrome.tabs
-          .sendMessage(tab.id, { action: MessageAction.RENDER_HIGHLIGHTS })
-          .catch((err) => {
-            console.log(err);
-          });
-    }
-  });
-
-  chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-    // Load collab whenever on fully loaded tabs
-    if (changeInfo.status === 'complete') {
-      chrome.tabs
-        .sendMessage(tabId, {
-          action: MessageAction.LOAD_COLLAB,
-          data: tab.url || '',
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    }
-  });
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  // Load collab whenever on fully loaded tabs
+  if (changeInfo.status === 'complete') {
+    chrome.tabs
+      .sendMessage(tabId, {
+        action: MessageAction.LOAD_COLLAB,
+        data: tab.url || '',
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
 });


### PR DESCRIPTION
This ensures that the extension works between tabs and highlights are preserved when switching between pages