### PR TITLE
fix: bug fixes and improvements

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -26,7 +26,7 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 
   if (details.reason === 'install' || details.reason === 'update') {
-    chrome.tabs.query({ currentWindow: true }, function (tabs) {
+    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       for (let tab of tabs) {
         if (!tab.id || !tab.url) return;
         try {

--- a/apps/extension/src/components/Highlights.tsx
+++ b/apps/extension/src/components/Highlights.tsx
@@ -11,18 +11,17 @@ type HighlightsProps = {
 
 export function Highlights({ showRecentOnly }: HighlightsProps) {
   const [highlights] = useNostrHighlights();
-  const highlightsToShow =  showRecentOnly ?
-  highlights.slice(0, 1) :highlights ;
-  
+  const highlightsToShow = showRecentOnly ? highlights.slice(0, 1) : highlights;
+
   return (
     <>
       {highlightsToShow.map((highlight) => (
-        <HighlightView {...highlight} key={highlight.id} />
+        <HighlightView {...highlight} key={highlight.range} />
       ))}
       {
         <AvatarGroup mt={4} size='md' max={3}>
-          {highlights.map(({ author, id }) => (
-            <Avatar name={author} src='https://bit.ly/code-beast' key={id} />
+          {highlights.map(({ author, range }) => (
+            <Avatar name={author} src='https://bit.ly/code-beast' key={range} />
           ))}
         </AvatarGroup>
       }
@@ -30,12 +29,12 @@ export function Highlights({ showRecentOnly }: HighlightsProps) {
   );
 }
 
-type HighlightViewProps = Pick<IHighlight, 'text' | 'author' | 'id'>;
+type HighlightViewProps = Pick<IHighlight, 'text' | 'author' | 'range'>;
 
-const HighlightView = ({ text, id }: HighlightViewProps) => {
+const HighlightView = ({ text, range }: HighlightViewProps) => {
   return (
     <Box
-      key={id}
+      key={range}
       mb='4'
       border={`1px solid ${theme.palette.lightGray}`}
       borderRadius='7px'

--- a/apps/extension/src/components/Highlights.tsx
+++ b/apps/extension/src/components/Highlights.tsx
@@ -16,12 +16,12 @@ export function Highlights({ showRecentOnly }: HighlightsProps) {
   return (
     <>
       {highlightsToShow.map((highlight) => (
-        <HighlightView {...highlight} key={highlight.range} />
+        <HighlightView {...highlight} key={highlight.id} />
       ))}
       {
         <AvatarGroup mt={4} size='md' max={3}>
-          {highlights.map(({ author, range }) => (
-            <Avatar name={author} src='https://bit.ly/code-beast' key={range} />
+          {highlights.map(({ author, id }) => (
+            <Avatar name={author} src='https://bit.ly/code-beast' key={id} />
           ))}
         </AvatarGroup>
       }
@@ -29,12 +29,12 @@ export function Highlights({ showRecentOnly }: HighlightsProps) {
   );
 }
 
-type HighlightViewProps = Pick<IHighlight, 'text' | 'author' | 'range'>;
+type HighlightViewProps = Pick<IHighlight, 'text' | 'author' | 'id'>;
 
-const HighlightView = ({ text, range }: HighlightViewProps) => {
+const HighlightView = ({ text, id }: HighlightViewProps) => {
   return (
     <Box
-      key={range}
+      key={id}
       mb='4'
       border={`1px solid ${theme.palette.lightGray}`}
       borderRadius='7px'

--- a/apps/extension/src/contentscript.ts
+++ b/apps/extension/src/contentscript.ts
@@ -82,7 +82,7 @@ chrome.runtime.onMessage.addListener(
           kinds: [KIND_HIGHLIGHT],
           tags: [['r', pageUrl]],
         };
-        let highlightsToLoad: any[] = [];
+        let highlightsToLoad: NDKEvent[] = [];
 
         if (debug) {
           const nostrHighlights = await ndk.fetchEvents(highlightFilter);

--- a/apps/extension/src/hooks/useNostrHighlights.tsx
+++ b/apps/extension/src/hooks/useNostrHighlights.tsx
@@ -20,11 +20,11 @@ export const useNostrHighlights = () => {
         .then((outcome: ActionResponse) => {
           if (outcome?.success) {
             const data = (outcome as SucccessAcionResponse).data;
-            // Check if every highlight has a text property before setting
-            const isAllDataWithText = data.every(highlight => highlight?.text)
-            if(isAllDataWithText && data.length > 0 ){
-             setHighlights(data as IHighlight[]);
-             return;
+            const isDataWithText =
+              data.length > 0 &&
+              data.every((highlight: Partial<IHighlight>) => highlight?.text);
+            if (isDataWithText) {
+              setHighlights(data as IHighlight[]);
             }
           }
         })

--- a/apps/extension/src/utils/Event.ts
+++ b/apps/extension/src/utils/Event.ts
@@ -1,17 +1,20 @@
 import { MessageAction } from '../types';
 
-export  function handleSidebar(action: MessageAction) {
- chrome.tabs.query({ active: true, currentWindow: true }, async function (tabs) {
-    const activeTab = tabs[0];
-    if (activeTab.id) {
-     await chrome.tabs.sendMessage(activeTab.id, {
-        action,
-      });
-     window.close(); 
-      
-      return;
+export function handleSidebar(action: MessageAction) {
+  chrome.tabs.query(
+    { active: true, currentWindow: true },
+    async function (tabs) {
+      const activeTab = tabs[0];
+      if (activeTab.id) {
+        await chrome.tabs.sendMessage(activeTab.id, {
+          action,
+        });
+        window.close();
+
+        return;
+      }
     }
-  });
+  );
 }
 
 export function openExtensionSettings() {


### PR DESCRIPTION
In this pr, to avoid spamming the relays during development, we don't publish the highlights but save to local storage. However, both in prod and dev we can view highlights from other urls. 
Also, I added a temporary solution to resource usage by ndk for opening and managing web sockets by only injecting the contentscript in active tabs.