### PR TITLE
remove extra extension permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build
 
 # other
 dist
+publish
 
 # misc
 .DS_Store

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -43,8 +43,6 @@
     "scripting",
     "storage",
     "tabs",
-    "webNavigation",
-    "webRequest",
     "activeTab"
   ],
   "host_permissions": ["<all_urls>"]


### PR DESCRIPTION
On first publish attempt, we realized [chrome.webNavigation](https://developer.chrome.com/docs/extensions/reference/webNavigation/) and [chrome.webRequest](https://developer.chrome.com/docs/extensions/reference/webRequest/) are extra permissions we don't need in the extension